### PR TITLE
fixed problem with version minimum of poetry dependencies ( 3.8 to 3.7)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 google-cloud-logging = "^1.15.1"
 neo4j = "1.7.6"
 fastapi = "^0.61.1"


### PR DESCRIPTION
When I execute **docker build** it generated the following exception

![Exception](http://i.prntscr.com/Ngc8Jb1dT8SQ0JcjAlPnaQ.png)

so I changed python 3.7 to 3.8 in the pyproject.toml

![OK](http://i.prntscr.com/IOw_cJLLTOibwglTNcTUVA.png)
